### PR TITLE
Add status code to zod error

### DIFF
--- a/src/express/createExpressSharedRouter.ts
+++ b/src/express/createExpressSharedRouter.ts
@@ -26,6 +26,7 @@ const makeValidationMiddleware =
       const zodError = error.cause as ZodError;
       res.status(400);
       res.json({
+        status: 400,
         message: error.message,
         issues: zodError.issues.map(
           ({ message, path }) => `${path.join(".")} : ${message}`,

--- a/test/expressAndSupertest.test.ts
+++ b/test/expressAndSupertest.test.ts
@@ -127,6 +127,7 @@ describe("createExpressSharedRouter and createSupertestSharedCaller", () => {
       queryParams: { max: "yolo" as any },
     });
     expect(getAllBooksResponse.body).toEqual({
+      status: 400,
       message:
         "Shared-route schema 'queryParamsSchema' was not respected in adapter 'express'.\nRoute: GET /books",
       issues: ["max : Expected number, received string"],


### PR DESCRIPTION
## What is the current behavior?
When there is a schema error, the server throws with an error with the following properties: `issues` and `message`

## What is the new behavior?
When there is a schema error, the server throws with an error with the following properties: **`status`**, `issues` and `message`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
